### PR TITLE
lock connection_pool to 2.5.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'sidekiq'
 gem 'sidekiq-unique-jobs'
 gem 'appsignal'
 gem 'dalli'
+gem "connection_pool", "<3"
 
 group :development, :test do
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
     commonmarker (2.6.0-x86_64-linux)
     commonmarker (2.6.0-x86_64-linux-musl)
     concurrent-ruby (1.3.5)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     counter_culture (3.11.4)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
@@ -338,6 +338,7 @@ DEPENDENCIES
   bootstrap-icons
   chartkick
   commonmarker
+  connection_pool (< 3)
   counter_culture
   dalli
   dotenv-rails
@@ -404,7 +405,7 @@ CHECKSUMS
   commonmarker (2.6.0-x86_64-linux) sha256=cddae70929aea45c6a8aa72bfc02d15029611b0e88fee965d0151bc9453fd8bb
   commonmarker (2.6.0-x86_64-linux-musl) sha256=10159e84446362daa92380f0f68fd3818affa86527f0f098d0d08ac49941538e
   concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
-  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  connection_pool (2.5.5) sha256=e54ff92855753df1fd7c59fa04a398833355f27dd14c074f8c83a05f72a716ad
   counter_culture (3.11.4) sha256=af64b6e429a2755057a7162826ea68ae354b869506199a6f521d171765c2ca38
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d


### PR DESCRIPTION
Pins connection_pool gem to <3 to ensure version 2.5.5 is used.