### PR TITLE
Support repository_url param on /api/v1/advisories/lookup

### DIFF
--- a/app/controllers/api/v1/advisories_controller.rb
+++ b/app/controllers/api/v1/advisories_controller.rb
@@ -48,25 +48,30 @@ class Api::V1::AdvisoriesController < Api::V1::ApplicationController
 
   def lookup
     purl = params[:purl]
-    
-    if purl.blank?
-      render json: { error: 'PURL parameter is required' }, status: :bad_request
+    repository_url = params[:repository_url]
+
+    if purl.blank? && repository_url.blank?
+      render json: { error: 'purl or repository_url parameter is required' }, status: :bad_request
       return
     end
 
-    parsed_purl = PurlParser.parse(purl)
-    
-    if parsed_purl.nil?
-      render json: { error: 'Invalid PURL format' }, status: :bad_request
-      return
+    if purl.present?
+      parsed_purl = PurlParser.parse(purl)
+
+      if parsed_purl.nil?
+        render json: { error: 'Invalid PURL format' }, status: :bad_request
+        return
+      end
+
+      scope = Advisory.ecosystem(parsed_purl[:ecosystem])
+                      .package_name(parsed_purl[:package_name])
+      @purl = purl
+    else
+      scope = Advisory.repository_url(repository_url)
     end
 
     expires_in 1.hour, public: true, stale_while_revalidate: 1.hour
 
-    scope = Advisory.ecosystem(parsed_purl[:ecosystem])
-                    .package_name(parsed_purl[:package_name])
-
-    @purl = purl
     @advisories = deduplicate_by_cve(scope)
   end
 

--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -117,22 +117,29 @@ paths:
                   $ref: '#/components/schemas/Package'
   /advisories/lookup:
     get:
-      summary: "lookup advisories by Package URL (PURL)"
-      operationId: "lookupAdvisoriesByPurl"
-      description: "Lookup security advisories for a package using Package URL (PURL) specification. Supports multiple ecosystems including npm, pypi, rubygems, maven, nuget, go, and cargo."
+      summary: "lookup advisories by Package URL (PURL) or repository URL"
+      operationId: "lookupAdvisories"
+      description: "Lookup security advisories for a package using Package URL (PURL) specification or by source repository URL. One of purl or repository_url must be provided. Results are deduplicated by CVE identifier."
       tags:
         - advisories
       parameters:
         - name: purl
           in: query
           description: "Package URL (PURL) to lookup advisories for. Format: pkg:type/namespace/name@version"
-          required: true
+          required: false
           schema:
             type: string
           example: "pkg:npm/lodash@4.17.20"
+        - name: repository_url
+          in: query
+          description: "Source repository URL to lookup advisories for"
+          required: false
+          schema:
+            type: string
+          example: "https://github.com/rails/rails"
       responses:
         200:
-          description: "List of advisories for the specified package"
+          description: "List of advisories for the specified package or repository"
           content:
             application/json:
               schema:
@@ -140,7 +147,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/Advisory'
         400:
-          description: "Bad Request - Invalid or missing PURL parameter"
+          description: "Bad Request - Invalid or missing parameter"
           content:
             application/json:
               schema:
@@ -148,7 +155,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: "PURL parameter is required"
+                    example: "purl or repository_url parameter is required"
   /advisories/{advisoryUUID}:
     get:
       summary: get a advisories by uuid

--- a/test/controllers/api/v1/advisories_controller_test.rb
+++ b/test/controllers/api/v1/advisories_controller_test.rb
@@ -181,22 +181,67 @@ class Api::V1::AdvisoriesControllerTest < ActionDispatch::IntegrationTest
       assert_equal 0, json_response.length
     end
 
-    should "return bad request for missing purl parameter" do
+    should "return bad request for missing parameters" do
       get lookup_api_v1_advisories_url, as: :json
-      
+
       assert_response :bad_request
       json_response = JSON.parse(response.body)
-      
-      assert_equal "PURL parameter is required", json_response["error"]
+
+      assert_equal "purl or repository_url parameter is required", json_response["error"]
     end
 
     should "return bad request for blank purl parameter" do
       get lookup_api_v1_advisories_url, params: { purl: "" }, as: :json
-      
+
       assert_response :bad_request
       json_response = JSON.parse(response.body)
-      
-      assert_equal "PURL parameter is required", json_response["error"]
+
+      assert_equal "purl or repository_url parameter is required", json_response["error"]
+    end
+
+    should "return advisories for repository_url" do
+      create(:advisory,
+        source: @source,
+        references: ["https://github.com/rails/rails/issues/1"],
+        packages: [{"ecosystem" => "rubygems", "package_name" => "rails", "versions" => []}]
+      )
+
+      get lookup_api_v1_advisories_url, params: { repository_url: "https://github.com/rails/rails" }, as: :json
+
+      assert_response :success
+      json_response = JSON.parse(response.body)
+
+      assert_equal 1, json_response.length
+      assert_equal "https://github.com/rails/rails", json_response.first["repository_url"]
+    end
+
+    should "return empty advisories for repository_url with no advisories" do
+      get lookup_api_v1_advisories_url, params: { repository_url: "https://github.com/foo/bar" }, as: :json
+
+      assert_response :success
+      json_response = JSON.parse(response.body)
+
+      assert_equal 0, json_response.length
+    end
+
+    should "deduplicate advisories with same CVE for repository_url" do
+      erlef_source = create(:source, kind: "erlef", url: "https://cna.erlef.org")
+
+      create(:advisory, source: @source,
+        references: ["https://github.com/rails/rails/issues/1"],
+        packages: [{"ecosystem" => "rubygems", "package_name" => "rails", "versions" => []}],
+        identifiers: ["CVE-2025-9999", "GHSA-test-9999"])
+
+      create(:advisory, source: erlef_source, uuid: "EEF-CVE-2025-9999",
+        references: ["https://github.com/rails/rails/issues/1"],
+        packages: [{"ecosystem" => "rubygems", "package_name" => "rails", "versions" => []}],
+        identifiers: ["CVE-2025-9999", "EEF-CVE-2025-9999"])
+
+      get lookup_api_v1_advisories_url, params: { repository_url: "https://github.com/rails/rails" }, as: :json
+      assert_response :success
+
+      json_response = JSON.parse(response.body)
+      assert_equal 1, json_response.length
     end
 
     should "return bad request for invalid purl format" do


### PR DESCRIPTION
Allows looking up advisories by source repository URL as an alternative to purl, e.g. `/api/v1/advisories/lookup?repository_url=https://github.com/rails/rails`.

Results are deduplicated by CVE the same way as purl lookups. Updated the OpenAPI spec and added controller tests.