### PR TITLE
Add CPAN Security Advisory Database source

### DIFF
--- a/app/controllers/advisories_controller.rb
+++ b/app/controllers/advisories_controller.rb
@@ -25,7 +25,7 @@ class AdvisoriesController < ApplicationController
     end
     scope = scope.source_kind(params[:source]) if params[:source].present?
 
-    @severities = scope.group(:severity).count.to_a.sort_by{|a| a[1]}.reverse
+    @severities = scope.where.not(severity: nil).group(:severity).count.to_a.sort_by{|a| a[1]}.reverse
     scope = scope.severity(params[:severity]) if params[:severity].present?
 
     cache_key = "advisories_ecosystem_counts_#{scope.to_sql.hash}"

--- a/app/controllers/ecosystems_controller.rb
+++ b/app/controllers/ecosystems_controller.rb
@@ -33,7 +33,7 @@ class EcosystemsController < ApplicationController
     @registry = Registry.find_by_ecosystem(@ecosystem)
     scope = Advisory.not_withdrawn.ecosystem(@ecosystem)
 
-    @severities = scope.group(:severity).count.to_a.sort_by{|a| a[1]}.reverse
+    @severities = scope.where.not(severity: nil).group(:severity).count.to_a.sort_by{|a| a[1]}.reverse
     scope = scope.severity(params[:severity]) if params[:severity].present?
 
     cache_key = "ecosystem_#{@ecosystem}_package_counts_#{scope.to_sql.hash}"
@@ -112,7 +112,7 @@ class EcosystemsController < ApplicationController
       scope = direct_scope
     end
 
-    @severities = scope.group(:severity).count.to_a.sort_by{|a| a[1]}.reverse
+    @severities = scope.where.not(severity: nil).group(:severity).count.to_a.sort_by{|a| a[1]}.reverse
     scope = scope.severity(params[:severity]) if params[:severity].present?
 
     cache_key = "ecosystem_#{@ecosystem}_package_#{@package_name}_repository_urls_#{scope.to_sql.hash}"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@ module ApplicationHelper
   include Pagy::Frontend
 
   def severity_class(severity)
-    case severity.downcase
+    case severity&.downcase
     when 'low'
       'bg-success'
     when 'moderate'

--- a/app/models/sources/cpansa.rb
+++ b/app/models/sources/cpansa.rb
@@ -18,7 +18,22 @@ module Sources
     end
 
     def map_advisories(advisories)
-      advisories.map { |advisory| map_advisory(advisory) }
+      advisories.group_by { |a| a['id'] }.map do |_id, entries|
+        map_advisory(merge_entries(entries))
+      end
+    end
+
+    def merge_entries(entries)
+      return entries.first if entries.length == 1
+
+      base = entries.first.dup
+      base['affected_versions'] = entries.flat_map { |e| Array(e['affected_versions']) }.uniq
+      base['fixed_versions'] = entries.flat_map { |e| Array(e['fixed_versions']) }.uniq
+      base['references'] = entries.flat_map { |e| Array(e['references']) }.compact.uniq
+      base['cves'] = entries.flat_map { |e| Array(e['cves']) }.compact.uniq
+      base['reported'] ||= entries.map { |e| e['reported'] }.compact.first
+      base['severity'] ||= entries.map { |e| e['severity'] }.compact.first
+      base
     end
 
     def map_advisory(advisory)
@@ -31,7 +46,7 @@ module Sources
         description: advisory['description']&.strip,
         origin: 'CPANSA',
         severity: normalize_severity(advisory['severity']),
-        published_at: advisory['reported'],
+        published_at: derive_published_at(advisory),
         withdrawn_at: nil,
         classification: nil,
         cvss_score: nil,
@@ -43,6 +58,28 @@ module Sources
         epss_percentile: nil,
         packages: extract_packages(advisory)
       }
+    end
+
+    def derive_published_at(advisory)
+      return advisory['reported'] if advisory['reported'].present?
+
+      year = year_from_cve(advisory['cves']) || year_from_id(advisory['id'])
+      return nil unless year
+
+      "#{year}-01-01"
+    end
+
+    def year_from_cve(cves)
+      Array(cves).each do |cve|
+        return $1 if cve =~ /\ACVE-(\d{4})-/
+      end
+      nil
+    end
+
+    def year_from_id(id)
+      return nil unless id
+      return $1 if id =~ /-((?:19|20)\d{2})-/
+      nil
     end
 
     def derive_title(advisory)

--- a/app/models/sources/cpansa.rb
+++ b/app/models/sources/cpansa.rb
@@ -1,0 +1,141 @@
+module Sources
+  class Cpansa < Base
+    DATA_URL = 'https://raw.githubusercontent.com/briandfoy/cpan-security-advisory/master/cpan-security-advisory.json'.freeze
+    REPO_URL = 'https://github.com/briandfoy/cpan-security-advisory'.freeze
+
+    def fetch_advisories
+      response = Faraday.get(DATA_URL)
+      return [] unless response.success?
+
+      json = JSON.parse(response.body)
+      dists = json['dists'] || {}
+
+      dists.flat_map do |dist_name, dist|
+        (dist['advisories'] || []).map do |advisory|
+          advisory.merge('distribution' => advisory['distribution'] || dist_name)
+        end
+      end
+    end
+
+    def map_advisories(advisories)
+      advisories.map { |advisory| map_advisory(advisory) }
+    end
+
+    def map_advisory(advisory)
+      references = Array(advisory['references']).compact
+
+      {
+        uuid: advisory['id'],
+        url: references.first || REPO_URL,
+        title: derive_title(advisory),
+        description: advisory['description']&.strip,
+        origin: 'CPANSA',
+        severity: normalize_severity(advisory['severity']),
+        published_at: advisory['reported'],
+        withdrawn_at: nil,
+        classification: nil,
+        cvss_score: nil,
+        cvss_vector: nil,
+        references: references,
+        source_kind: 'cpansa',
+        identifiers: extract_identifiers(advisory),
+        epss_percentage: nil,
+        epss_percentile: nil,
+        packages: extract_packages(advisory)
+      }
+    end
+
+    def derive_title(advisory)
+      description = advisory['description'].to_s.strip
+      return advisory['id'] if description.blank?
+
+      description.split("\n").first.truncate(255)
+    end
+
+    def extract_identifiers(advisory)
+      ids = [advisory['id']]
+      ids += Array(advisory['cves'])
+      ids.compact.uniq
+    end
+
+    def extract_packages(advisory)
+      dist = advisory['distribution']
+      return [] if dist.blank?
+
+      affected = Array(advisory['affected_versions'])
+      fixed = Array(advisory['fixed_versions'])
+
+      versions = if affected.any?
+        affected.each_with_index.map do |range, i|
+          {
+            vulnerable_version_range: normalize_range(range),
+            first_patched_version: extract_patched_version(fixed[i] || fixed.first)
+          }
+        end
+      elsif fixed.any?
+        fixed.map do |range|
+          {
+            vulnerable_version_range: invert_fixed_range(range),
+            first_patched_version: extract_patched_version(range)
+          }
+        end
+      else
+        []
+      end
+
+      return [] if versions.empty?
+
+      [{
+        ecosystem: 'cpan',
+        package_name: dist,
+        versions: versions
+      }]
+    end
+
+    def normalize_range(range)
+      return nil if range.blank?
+
+      range.split(',').map { |part| normalize_constraint(part) }.compact.join(', ')
+    end
+
+    def normalize_constraint(constraint)
+      constraint = constraint.strip
+      return nil if constraint.blank?
+
+      if (match = constraint.match(/\A(<=|>=|==|!=|<|>|=)\s*(.+)\z/))
+        op = match[1] == '==' ? '=' : match[1]
+        "#{op} #{match[2].strip}"
+      else
+        "= #{constraint}"
+      end
+    end
+
+    def extract_patched_version(fixed)
+      return nil if fixed.blank?
+
+      fixed.strip.sub(/\A>=?\s*/, '')
+    end
+
+    def invert_fixed_range(fixed)
+      version = extract_patched_version(fixed)
+      return nil if version.blank?
+
+      "< #{version}"
+    end
+
+    def normalize_severity(severity)
+      return nil if severity.blank?
+
+      case severity.downcase
+      when 'critical'
+        'CRITICAL'
+      when 'high'
+        'HIGH'
+      when 'moderate', 'medium'
+        'MODERATE'
+      when 'low', 'minor'
+        'LOW'
+      end
+    end
+  end
+end

--- a/app/views/advisories/_advisory.html.erb
+++ b/app/views/advisories/_advisory.html.erb
@@ -8,7 +8,7 @@
     <div class="text-muted float-end listing__time">
         <% if advisory.withdrawn? %>
           <span title="<%= advisory.withdrawn_at %>">Withdrawn <%= time_ago_in_words advisory.withdrawn_at %> ago</span>
-        <% else %>
+        <% elsif advisory.published_at %>
           <span title="<%= advisory.published_at %>"><%= time_ago_in_words advisory.published_at %> ago</span>
         <% end %>
     </div>

--- a/app/views/advisories/show.html.erb
+++ b/app/views/advisories/show.html.erb
@@ -15,7 +15,9 @@
 
     <div class="advisory-header__meta d-flex flex-wrap align-items-center mb-4">
       <div class="d-flex flex-wrap flex-grow-1 mb-2">
+        <% if @advisory.severity %>
         <span class="me-4 mb-2 badge <%= severity_class(@advisory.severity)%>"><%= @advisory.severity.humanize %></span>
+        <% end %>
         <% if @advisory.cvss_score && @advisory.cvss_score > 0 %>
         <span class="me-4 mb-2 advisory-header__meta__text">CVSS: <%= @advisory.cvss_score %></span>
         <% end %>
@@ -236,8 +238,10 @@
           <p><%= identifier %></p>
         <% end %>
         <h2>Risk</h2>
+        <% if @advisory.severity %>
         <h3>Severity</h3>
         <p><span class='me-4 badge <%= severity_class(@advisory.severity)%>'><%= @advisory.severity.humanize %></span> </p>
+        <% end %>
         <!--
         <h3>Blast radius</h3>
         <p><%= @advisory.blast_radius.round(1) %> </p>

--- a/app/views/advisories/show.html.erb
+++ b/app/views/advisories/show.html.erb
@@ -280,8 +280,10 @@
         </p>
         <% end %>
         <h2>Date and time</h2>
+        <% if @advisory.published_at %>
         <h3>Published</h3>
         <p><span title="<%= @advisory.published_at %>"><%= time_ago_in_words @advisory.published_at %> ago</span></p>
+        <% end %>
         <h3>Updated</h3>
         <p><span title="<%= @advisory.updated_at %>"><%= time_ago_in_words @advisory.updated_at %> ago</span></p>
         <% if @advisory.withdrawn_at %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,7 @@
 default_sources = [
   {name: 'GitHub Advisory Database', kind: 'github', url: 'https://github.com/advisories'},
   {name: 'Erlang Ecosystem Foundation', kind: 'erlef', url: 'https://cna.erlef.org'},
+  {name: 'CPAN Security Advisory Database', kind: 'cpansa', url: 'https://github.com/briandfoy/cpan-security-advisory'},
 ]
 
 default_sources.each do |source|

--- a/lib/tasks/advisories.rake
+++ b/lib/tasks/advisories.rake
@@ -23,4 +23,14 @@ namespace :advisories do
       puts "Erlef source not found. Run `rails db:seed` to create it."
     end
   end
+
+  desc 'Update advisories from CPAN Security Advisory Database'
+  task :sync_cpansa => :environment do
+    source = Source.find_by(kind: 'cpansa')
+    if source
+      source.sync_advisories
+    else
+      puts "CPANSA source not found. Run `rails db:seed` to create it."
+    end
+  end
 end

--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -49,7 +49,7 @@ paths:
             type: string
         - name: source
           in: query
-          description: "Source to filter by (e.g. github, erlef)"
+          description: "Source to filter by (e.g. github, erlef, cpansa)"
           required: false
           schema:
             type: string
@@ -203,7 +203,7 @@ paths:
           schema:
             type: string
           required: true
-          description: kind of the source (e.g. github, erlef)
+          description: kind of the source (e.g. github, erlef, cpansa)
       responses:
         200:
           description: OK

--- a/test/controllers/advisories_controller_test.rb
+++ b/test/controllers/advisories_controller_test.rb
@@ -187,8 +187,8 @@ class AdvisoriesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should render advisory without published_at on show" do
-    advisory = FactoryBot.create(:advisory, source: @source, published_at: nil)
+  test "should render advisory without published_at or severity on show" do
+    advisory = FactoryBot.create(:advisory, source: @source, published_at: nil, severity: nil)
 
     get advisory_url(advisory)
     assert_response :success

--- a/test/controllers/advisories_controller_test.rb
+++ b/test/controllers/advisories_controller_test.rb
@@ -180,8 +180,8 @@ class AdvisoriesControllerTest < ActionDispatch::IntegrationTest
     assert_select "h3", text: "Potentially Affected Packages", count: 0
   end
 
-  test "should render advisory without published_at on index" do
-    FactoryBot.create(:advisory, source: @source, published_at: nil)
+  test "should render advisory without published_at or severity on index" do
+    FactoryBot.create(:advisory, source: @source, published_at: nil, severity: nil)
 
     get advisories_url
     assert_response :success

--- a/test/controllers/advisories_controller_test.rb
+++ b/test/controllers/advisories_controller_test.rb
@@ -180,6 +180,20 @@ class AdvisoriesControllerTest < ActionDispatch::IntegrationTest
     assert_select "h3", text: "Potentially Affected Packages", count: 0
   end
 
+  test "should render advisory without published_at on index" do
+    FactoryBot.create(:advisory, source: @source, published_at: nil)
+
+    get advisories_url
+    assert_response :success
+  end
+
+  test "should render advisory without published_at on show" do
+    advisory = FactoryBot.create(:advisory, source: @source, published_at: nil)
+
+    get advisory_url(advisory)
+    assert_response :success
+  end
+
   test "should filter by source and show correct advisories" do
     erlef_source = FactoryBot.create(:source, kind: "erlef", url: "https://cna.erlef.org")
     FactoryBot.create(:advisory, source: erlef_source, uuid: "EEF-CVE-2025-0001")

--- a/test/controllers/ecosystems_controller_test.rb
+++ b/test/controllers/ecosystems_controller_test.rb
@@ -61,6 +61,24 @@ class EcosystemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a.list-group-item", { text: /pandas/, count: 0 }
   end
 
+  test "should render ecosystem page with nil severity advisories" do
+    FactoryBot.create(:advisory, source: @source, severity: nil, packages: [
+      { "ecosystem" => "pypi", "package_name" => "tensorflow", "versions" => [{"vulnerable_version_range" => "< 1.0"}] }
+    ])
+
+    get ecosystem_url("pypi")
+    assert_response :success
+  end
+
+  test "should render package page with nil severity advisories" do
+    FactoryBot.create(:advisory, source: @source, severity: nil, packages: [
+      { "ecosystem" => "pypi", "package_name" => "tensorflow", "versions" => [{"vulnerable_version_range" => "< 1.0"}] }
+    ])
+
+    get ecosystem_package_url("pypi", "tensorflow")
+    assert_response :success
+  end
+
   test "should handle severity filter on ecosystem page" do
     get ecosystem_url("pypi"), params: { severity: "high" }
     assert_response :success

--- a/test/models/sources/cpansa_test.rb
+++ b/test/models/sources/cpansa_test.rb
@@ -72,6 +72,65 @@ class CpansaSourceTest < ActiveSupport::TestCase
     assert_equal "1.23", package[:versions].first[:first_patched_version]
   end
 
+  test "map_advisories merges duplicate ids into one advisory with combined ranges" do
+    entries = [
+      {
+        "id" => "CPANSA-Dup-2021-01",
+        "distribution" => "Dup-Dist",
+        "description" => "Issue",
+        "affected_versions" => [">=2.1.0,<=2.1.1"],
+        "fixed_versions" => [],
+        "cves" => ["CVE-2021-0001"],
+        "references" => ["https://a"],
+        "reported" => nil
+      },
+      {
+        "id" => "CPANSA-Dup-2021-01",
+        "distribution" => "Dup-Dist",
+        "description" => "Issue",
+        "affected_versions" => ["==2.5.0"],
+        "fixed_versions" => [">=2.6.0"],
+        "cves" => ["CVE-2021-0001"],
+        "references" => ["https://b"],
+        "reported" => "2021-03-01"
+      }
+    ]
+
+    mapped = @cpansa.map_advisories(entries)
+
+    assert_equal 1, mapped.length
+    advisory = mapped.first
+    assert_equal "CPANSA-Dup-2021-01", advisory[:uuid]
+    assert_equal "2021-03-01", advisory[:published_at]
+    assert_equal ["https://a", "https://b"], advisory[:references]
+
+    versions = advisory[:packages].first[:versions]
+    assert_equal 2, versions.length
+    assert_equal ">= 2.1.0, <= 2.1.1", versions[0][:vulnerable_version_range]
+    assert_equal "= 2.5.0", versions[1][:vulnerable_version_range]
+    assert_equal "2.6.0", versions[1][:first_patched_version]
+  end
+
+  test "derive_published_at prefers reported date" do
+    advisory = { "reported" => "2020-05-01", "cves" => ["CVE-2019-0001"], "id" => "CPANSA-Foo-2018-01" }
+    assert_equal "2020-05-01", @cpansa.derive_published_at(advisory)
+  end
+
+  test "derive_published_at falls back to CVE year" do
+    advisory = { "reported" => nil, "cves" => ["CVE-2019-0001"], "id" => "CPANSA-Foo-2018-01" }
+    assert_equal "2019-01-01", @cpansa.derive_published_at(advisory)
+  end
+
+  test "derive_published_at falls back to id year when no CVE" do
+    advisory = { "reported" => nil, "cves" => [], "id" => "CPANSA-Foo-2018-01-jquery" }
+    assert_equal "2018-01-01", @cpansa.derive_published_at(advisory)
+  end
+
+  test "derive_published_at returns nil when nothing available" do
+    advisory = { "reported" => nil, "cves" => [], "id" => "CPANSA-MySQL-Admin-1-1" }
+    assert_nil @cpansa.derive_published_at(advisory)
+  end
+
   test "map_advisory pairs multiple affected ranges with fixed versions" do
     advisory = {
       "id" => "CPANSA-Multi-2020-01",

--- a/test/models/sources/cpansa_test.rb
+++ b/test/models/sources/cpansa_test.rb
@@ -1,0 +1,249 @@
+require "test_helper"
+require "webmock/minitest"
+
+class CpansaSourceTest < ActiveSupport::TestCase
+  def setup
+    WebMock.disable_net_connect!
+    @source = Source.create!(name: "CPAN Security Advisory Database", kind: "cpansa", url: "https://github.com/briandfoy/cpan-security-advisory")
+    @cpansa = Sources::Cpansa.new(@source)
+  end
+
+  def teardown
+    WebMock.allow_net_connect!
+  end
+
+  test "fetch_advisories flattens dists into advisory list" do
+    stub_request(:get, Sources::Cpansa::DATA_URL)
+      .to_return(status: 200, body: sample_payload.to_json)
+
+    advisories = @cpansa.fetch_advisories
+
+    assert_equal 3, advisories.length
+    assert_equal "CPANSA-HTTP-Body-2013-4407", advisories[0]["id"]
+    assert_equal "HTTP-Body", advisories[0]["distribution"]
+    assert_equal "Catalyst-Controller-Combine", advisories[2]["distribution"]
+  end
+
+  test "fetch_advisories returns empty array on http failure" do
+    stub_request(:get, Sources::Cpansa::DATA_URL).to_return(status: 500)
+
+    assert_equal [], @cpansa.fetch_advisories
+  end
+
+  test "map_advisory extracts core fields" do
+    mapped = @cpansa.map_advisory(http_body_advisory)
+
+    assert_equal "CPANSA-HTTP-Body-2013-4407", mapped[:uuid]
+    assert_equal "https://www.openwall.com/lists/oss-security/2024/04/07/1", mapped[:url]
+    assert_equal "CPANSA", mapped[:origin]
+    assert_equal "cpansa", mapped[:source_kind]
+    assert_equal "MODERATE", mapped[:severity]
+    assert_equal "2013-09-02", mapped[:published_at]
+    assert_nil mapped[:withdrawn_at]
+    assert_nil mapped[:cvss_score]
+    assert_equal http_body_advisory["references"], mapped[:references]
+    assert_equal "HTTP::Body::Multipart in the HTTP-Body 1.08, 1.22, and earlier module for Perl is vulnerable.", mapped[:description]
+    assert_equal "HTTP::Body::Multipart in the HTTP-Body 1.08, 1.22, and earlier module for Perl is vulnerable.", mapped[:title]
+  end
+
+  test "map_advisory builds identifiers from id and cves" do
+    mapped = @cpansa.map_advisory(http_body_advisory)
+
+    assert_equal ["CPANSA-HTTP-Body-2013-4407", "CVE-2013-4407"], mapped[:identifiers]
+  end
+
+  test "map_advisory handles advisory without cves or references" do
+    mapped = @cpansa.map_advisory(catalyst_advisory)
+
+    assert_equal ["CPANSA-Catalyst-Controller-Combine-2010-01"], mapped[:identifiers]
+    assert_equal Sources::Cpansa::REPO_URL, mapped[:url]
+    assert_nil mapped[:severity]
+  end
+
+  test "map_advisory extracts package with normalized version ranges" do
+    mapped = @cpansa.map_advisory(http_body_advisory)
+
+    assert_equal 1, mapped[:packages].length
+    package = mapped[:packages].first
+    assert_equal "cpan", package[:ecosystem]
+    assert_equal "HTTP-Body", package[:package_name]
+    assert_equal 1, package[:versions].length
+    assert_equal ">= 1.08, < 1.23", package[:versions].first[:vulnerable_version_range]
+    assert_equal "1.23", package[:versions].first[:first_patched_version]
+  end
+
+  test "map_advisory pairs multiple affected ranges with fixed versions" do
+    advisory = {
+      "id" => "CPANSA-Multi-2020-01",
+      "distribution" => "Multi-Dist",
+      "description" => "Multiple ranges",
+      "affected_versions" => ["==1.08", "==2.07"],
+      "fixed_versions" => [">=2.08"],
+      "cves" => [],
+      "reported" => "2020-01-01"
+    }
+
+    mapped = @cpansa.map_advisory(advisory)
+    versions = mapped[:packages].first[:versions]
+
+    assert_equal 2, versions.length
+    assert_equal "= 1.08", versions[0][:vulnerable_version_range]
+    assert_equal "2.08", versions[0][:first_patched_version]
+    assert_equal "= 2.07", versions[1][:vulnerable_version_range]
+    assert_equal "2.08", versions[1][:first_patched_version]
+  end
+
+  test "map_advisory derives range from fixed_versions when affected is empty" do
+    advisory = {
+      "id" => "CPANSA-FixedOnly-2020-01",
+      "distribution" => "Fixed-Only",
+      "description" => "Only fixed version known",
+      "affected_versions" => [],
+      "fixed_versions" => [">=1.5.0"],
+      "cves" => [],
+      "reported" => "2020-01-01"
+    }
+
+    mapped = @cpansa.map_advisory(advisory)
+    versions = mapped[:packages].first[:versions]
+
+    assert_equal 1, versions.length
+    assert_equal "< 1.5.0", versions[0][:vulnerable_version_range]
+    assert_equal "1.5.0", versions[0][:first_patched_version]
+  end
+
+  test "map_advisory returns no packages when no version info" do
+    advisory = {
+      "id" => "CPANSA-Empty-2020-01",
+      "distribution" => "Empty-Dist",
+      "description" => "No version info",
+      "affected_versions" => [],
+      "fixed_versions" => [],
+      "cves" => [],
+      "reported" => "2020-01-01"
+    }
+
+    mapped = @cpansa.map_advisory(advisory)
+
+    assert_equal [], mapped[:packages]
+  end
+
+  test "normalize_range handles operator and bare version formats" do
+    assert_equal "< 0.12", @cpansa.normalize_range("<0.12")
+    assert_equal ">= 1.08, < 1.23", @cpansa.normalize_range(">=1.08,<1.23")
+    assert_equal "= 1.08", @cpansa.normalize_range("==1.08")
+    assert_equal "= 1.9.1", @cpansa.normalize_range("1.9.1")
+    assert_equal "<= 5.2.1.2", @cpansa.normalize_range("<=5.2.1.2")
+    assert_equal "> 7.83, < 7.92", @cpansa.normalize_range(">7.83,<7.92")
+    assert_nil @cpansa.normalize_range(nil)
+    assert_nil @cpansa.normalize_range("")
+  end
+
+  test "extract_patched_version strips leading operator" do
+    assert_equal "1.23", @cpansa.extract_patched_version(">=1.23")
+    assert_equal "1.23", @cpansa.extract_patched_version(">= 1.23")
+    assert_equal "1.23", @cpansa.extract_patched_version(">1.23")
+    assert_equal "1.23", @cpansa.extract_patched_version("1.23")
+    assert_nil @cpansa.extract_patched_version(nil)
+    assert_nil @cpansa.extract_patched_version("")
+  end
+
+  test "normalize_severity maps cpansa values to standard set" do
+    assert_equal "CRITICAL", @cpansa.normalize_severity("critical")
+    assert_equal "HIGH", @cpansa.normalize_severity("high")
+    assert_equal "MODERATE", @cpansa.normalize_severity("moderate")
+    assert_equal "MODERATE", @cpansa.normalize_severity("medium")
+    assert_equal "LOW", @cpansa.normalize_severity("low")
+    assert_equal "LOW", @cpansa.normalize_severity("minor")
+    assert_nil @cpansa.normalize_severity(nil)
+    assert_nil @cpansa.normalize_severity("unknown")
+  end
+
+  test "derive_title falls back to id when description blank" do
+    advisory = { "id" => "CPANSA-Test-2020-01", "description" => "" }
+    assert_equal "CPANSA-Test-2020-01", @cpansa.derive_title(advisory)
+  end
+
+  test "derive_title uses first line of description" do
+    advisory = { "id" => "CPANSA-Test-2020-01", "description" => "First line.\nSecond line." }
+    assert_equal "First line.", @cpansa.derive_title(advisory)
+  end
+
+  test "sync_advisories creates advisories in database" do
+    Sidekiq::Testing.fake! do
+      stub_request(:get, Sources::Cpansa::DATA_URL)
+        .to_return(status: 200, body: sample_payload.to_json)
+
+      assert_difference "Advisory.count", 3 do
+        @source.sync_advisories
+      end
+
+      created = Advisory.find_by(uuid: "CPANSA-HTTP-Body-2013-4407")
+      assert_not_nil created
+      assert_equal @source, created.source
+      assert_equal "MODERATE", created.severity
+      assert_includes created.identifiers, "CVE-2013-4407"
+      assert_equal "cpan", created.packages.first["ecosystem"]
+      assert_equal "HTTP-Body", created.packages.first["package_name"]
+    end
+  end
+
+  def sample_payload
+    {
+      "meta" => { "date" => "Sun Apr 19 16:34:00 2026" },
+      "dists" => {
+        "HTTP-Body" => {
+          "advisories" => [http_body_advisory, http_body_second_advisory],
+          "main_module" => "HTTP::Body"
+        },
+        "Catalyst-Controller-Combine" => {
+          "advisories" => [catalyst_advisory],
+          "main_module" => "Catalyst::Controller::Combine"
+        }
+      }
+    }
+  end
+
+  def http_body_advisory
+    {
+      "id" => "CPANSA-HTTP-Body-2013-4407",
+      "distribution" => "HTTP-Body",
+      "severity" => "moderate",
+      "fixed_versions" => [">=1.23"],
+      "reported" => "2013-09-02",
+      "affected_versions" => [">=1.08,<1.23"],
+      "cves" => ["CVE-2013-4407"],
+      "description" => "HTTP::Body::Multipart in the HTTP-Body 1.08, 1.22, and earlier module for Perl is vulnerable.\n",
+      "references" => [
+        "https://www.openwall.com/lists/oss-security/2024/04/07/1",
+        "https://security-tracker.debian.org/tracker/CVE-2013-4407"
+      ]
+    }
+  end
+
+  def http_body_second_advisory
+    {
+      "id" => "CPANSA-HTTP-Body-2020-01",
+      "distribution" => "HTTP-Body",
+      "severity" => "high",
+      "fixed_versions" => [],
+      "reported" => "2020-01-01",
+      "affected_versions" => ["<1.30"],
+      "cves" => [],
+      "description" => "Another issue.\n",
+      "references" => ["https://metacpan.org/changes/distribution/HTTP-Body"]
+    }
+  end
+
+  def catalyst_advisory
+    {
+      "id" => "CPANSA-Catalyst-Controller-Combine-2010-01",
+      "distribution" => "Catalyst-Controller-Combine",
+      "fixed_versions" => [">=0.12"],
+      "reported" => "2010-05-21",
+      "affected_versions" => ["<0.12"],
+      "cves" => [],
+      "description" => "Allows reading files outside the intended directory.\n"
+    }
+  end
+end


### PR DESCRIPTION
Ingests advisories from briandfoy/cpan-security-advisory, the canonical source for CPAN vulnerabilities. OSV doesn't cover CPAN and NVD doesn't map CVEs to distribution names, so this is the only source linking CPAN dists to their advisories.

Fetches the single `cpan-security-advisory.json` file and maps each entry to our schema with `ecosystem: cpan`, matching the metacpan.org registry in packages.ecosyste.ms. CPANSA repeats the same advisory id once per disjoint version range, so entries are grouped by `id` and merged into a single advisory carrying all ranges (1727 raw entries become 801 advisories across 320 distributions, ~94% with CVE identifiers).

Version ranges are normalized from CPANSA format (`>=1.08,<1.23`, `==1.08`, bare `1.9.1`) to the GitHub-style format the `vers` gem accepts. Severity values (`medium`, `moderate`, `minor`, etc.) are mapped to CRITICAL/HIGH/MODERATE/LOW. Titles are derived from the first line of the description since CPANSA has no summary field. When `reported` is missing, `published_at` falls back to the year from the CVE id or the CPANSA id.

Also hardens the advisory views and severity filter against nil `published_at` and nil `severity`, since a chunk of CPANSA entries lack one or both and previously every advisory came from GitHub with both populated.

After deploy: run `rails db:seed` then `rake advisories:sync_cpansa`.

Fixes #1038