### PR TITLE
Add advisory RSS and Atom feeds

### DIFF
--- a/app/controllers/advisories_controller.rb
+++ b/app/controllers/advisories_controller.rb
@@ -74,6 +74,12 @@ class AdvisoriesController < ApplicationController
     expires_in 1.hour, public: true, stale_while_revalidate: 1.hour
 
     @pagy, @advisories = pagy(scope.includes(:source))
+
+    respond_to do |format|
+      format.html
+      format.rss
+      format.atom
+    end
   end
 
   def recent_advisories_data

--- a/app/controllers/ecosystems_controller.rb
+++ b/app/controllers/ecosystems_controller.rb
@@ -76,6 +76,12 @@ class EcosystemsController < ApplicationController
     end
 
     @pagy, @advisories = pagy(scope.includes(:source))
+
+    respond_to do |format|
+      format.html
+      format.rss
+      format.atom
+    end
   end
 
   def packages
@@ -152,6 +158,12 @@ class EcosystemsController < ApplicationController
 
     if @package
       @related_packages_by_advisory = @package.related_packages.index_by(&:advisory_id)
+    end
+
+    respond_to do |format|
+      format.html
+      format.rss
+      format.atom
     end
   end
 end

--- a/app/views/advisories/index.atom.builder
+++ b/app/views/advisories/index.atom.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.feed xmlns: 'http://www.w3.org/2005/Atom' do
+  xml.title @title || 'Security Advisories'
+  xml.subtitle 'Security advisories indexed by ecosyste.ms'
+  xml.id request.original_url.sub(/\.(rss|atom)(\?|$)/, '\2')
+  xml.link href: request.original_url.sub(/\.(rss|atom)(\?|$)/, '\2')
+  xml.link href: url_for(request.query_parameters.merge(format: :atom, only_path: false)), rel: 'self', type: 'application/atom+xml'
+  xml.updated((@advisories.first&.published_at || Time.current).iso8601)
+
+  @advisories.each do |advisory|
+    xml.entry do
+      xml.title advisory.title
+      xml.id advisory_url(advisory)
+      xml.link href: advisory_url(advisory)
+      xml.updated((advisory.updated_at || advisory.published_at || Time.current).iso8601)
+      xml.summary advisory.uuid
+    end
+  end
+end

--- a/app/views/advisories/index.html.erb
+++ b/app/views/advisories/index.html.erb
@@ -1,3 +1,8 @@
+<% content_for :head do %>
+  <%= auto_discovery_link_tag(:rss, url_for(request.query_parameters.merge(format: :rss)), title: "Advisories RSS") %>
+  <%= auto_discovery_link_tag(:atom, url_for(request.query_parameters.merge(format: :atom)), title: "Advisories Atom") %>
+<% end %>
+
 <% @meta_description = "Browse all Security Advisories #{params[:severity].try(:humanize)} #{params[:ecosystem]} #{params[:package_name]} #{params[:repository_url]} #{params[:source]}" %>
 
 <div class="container">

--- a/app/views/advisories/index.rss.builder
+++ b/app/views/advisories/index.rss.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.rss version: '2.0' do
+  xml.channel do
+    xml.title @title || 'Security Advisories'
+    xml.description 'Security advisories indexed by ecosyste.ms'
+    xml.link request.original_url.sub(/\.(rss|atom)(\?|$)/, '\2')
+    xml.language 'en'
+
+    @advisories.each do |advisory|
+      xml.item do
+        xml.title advisory.title
+        xml.description advisory.uuid
+        xml.link advisory_url(advisory)
+        xml.guid advisory_url(advisory), isPermaLink: true
+        xml.pubDate advisory.published_at.rfc2822 if advisory.published_at.present?
+      end
+    end
+  end
+end

--- a/app/views/ecosystems/package.atom.builder
+++ b/app/views/ecosystems/package.atom.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.feed xmlns: 'http://www.w3.org/2005/Atom' do
+  xml.title @title || 'Security Advisories'
+  xml.subtitle 'Security advisories indexed by ecosyste.ms'
+  xml.id request.original_url.sub(/\.(rss|atom)(\?|$)/, '\2')
+  xml.link href: request.original_url.sub(/\.(rss|atom)(\?|$)/, '\2')
+  xml.link href: url_for(request.query_parameters.merge(format: :atom, only_path: false)), rel: 'self', type: 'application/atom+xml'
+  xml.updated((@advisories.first&.published_at || Time.current).iso8601)
+
+  @advisories.each do |advisory|
+    xml.entry do
+      xml.title advisory.title
+      xml.id advisory_url(advisory)
+      xml.link href: advisory_url(advisory)
+      xml.updated((advisory.updated_at || advisory.published_at || Time.current).iso8601)
+      xml.summary advisory.uuid
+    end
+  end
+end

--- a/app/views/ecosystems/package.html.erb
+++ b/app/views/ecosystems/package.html.erb
@@ -1,3 +1,8 @@
+<% content_for :head do %>
+  <%= auto_discovery_link_tag(:rss, url_for(request.query_parameters.merge(format: :rss)), title: "Package Advisories RSS") %>
+  <%= auto_discovery_link_tag(:atom, url_for(request.query_parameters.merge(format: :atom)), title: "Package Advisories Atom") %>
+<% end %>
+
 <% @meta_title = "#{@package_name} Security Advisories - #{@ecosystem.humanize}" %>
 <% if @package&.description.present? %>
   <% @meta_description = "Security advisories for #{@package_name} (#{@ecosystem}): #{@package.description.truncate(120)}" %>

--- a/app/views/ecosystems/package.rss.builder
+++ b/app/views/ecosystems/package.rss.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.rss version: '2.0' do
+  xml.channel do
+    xml.title @title || 'Security Advisories'
+    xml.description 'Security advisories indexed by ecosyste.ms'
+    xml.link request.original_url.sub(/\.(rss|atom)(\?|$)/, '\2')
+    xml.language 'en'
+
+    @advisories.each do |advisory|
+      xml.item do
+        xml.title advisory.title
+        xml.description advisory.uuid
+        xml.link advisory_url(advisory)
+        xml.guid advisory_url(advisory), isPermaLink: true
+        xml.pubDate advisory.published_at.rfc2822 if advisory.published_at.present?
+      end
+    end
+  end
+end

--- a/app/views/ecosystems/show.atom.builder
+++ b/app/views/ecosystems/show.atom.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.feed xmlns: 'http://www.w3.org/2005/Atom' do
+  xml.title @title || 'Security Advisories'
+  xml.subtitle 'Security advisories indexed by ecosyste.ms'
+  xml.id request.original_url.sub(/\.(rss|atom)(\?|$)/, '\2')
+  xml.link href: request.original_url.sub(/\.(rss|atom)(\?|$)/, '\2')
+  xml.link href: url_for(request.query_parameters.merge(format: :atom, only_path: false)), rel: 'self', type: 'application/atom+xml'
+  xml.updated((@advisories.first&.published_at || Time.current).iso8601)
+
+  @advisories.each do |advisory|
+    xml.entry do
+      xml.title advisory.title
+      xml.id advisory_url(advisory)
+      xml.link href: advisory_url(advisory)
+      xml.updated((advisory.updated_at || advisory.published_at || Time.current).iso8601)
+      xml.summary advisory.uuid
+    end
+  end
+end

--- a/app/views/ecosystems/show.html.erb
+++ b/app/views/ecosystems/show.html.erb
@@ -1,3 +1,8 @@
+<% content_for :head do %>
+  <%= auto_discovery_link_tag(:rss, url_for(request.query_parameters.merge(format: :rss)), title: "Ecosystem Advisories RSS") %>
+  <%= auto_discovery_link_tag(:atom, url_for(request.query_parameters.merge(format: :atom)), title: "Ecosystem Advisories Atom") %>
+<% end %>
+
 <% @meta_title = "#{@ecosystem.humanize} Security Advisories" %>
 <% @meta_description = "Browse and search security advisories for #{@ecosystem} packages. View CVE details, severity ratings, and affected versions." %>
 

--- a/app/views/ecosystems/show.rss.builder
+++ b/app/views/ecosystems/show.rss.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.rss version: '2.0' do
+  xml.channel do
+    xml.title @title || 'Security Advisories'
+    xml.description 'Security advisories indexed by ecosyste.ms'
+    xml.link request.original_url.sub(/\.(rss|atom)(\?|$)/, '\2')
+    xml.language 'en'
+
+    @advisories.each do |advisory|
+      xml.item do
+        xml.title advisory.title
+        xml.description advisory.uuid
+        xml.link advisory_url(advisory)
+        xml.guid advisory_url(advisory), isPermaLink: true
+        xml.pubDate advisory.published_at.rfc2822 if advisory.published_at.present?
+      end
+    end
+  end
+end

--- a/test/controllers/advisories_controller_test.rb
+++ b/test/controllers/advisories_controller_test.rb
@@ -12,6 +12,30 @@ class AdvisoriesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "max-age=3600, public, stale-while-revalidate=3600", response.headers["Cache-Control"]
   end
 
+
+  test "provides RSS and Atom auto discovery links" do
+    get advisories_url
+    assert_response :success
+    assert_select 'link[rel="alternate"][type="application/rss+xml"]'
+    assert_select 'link[rel="alternate"][type="application/atom+xml"]'
+  end
+
+  test "renders RSS feed" do
+    get advisories_url(format: :rss)
+    assert_response :success
+    assert_equal 'application/rss+xml', response.media_type
+    assert_includes response.body, '<rss'
+    assert_includes response.body, @advisory.uuid
+  end
+
+  test "renders Atom feed" do
+    get advisories_url(format: :atom)
+    assert_response :success
+    assert_equal 'application/atom+xml', response.media_type
+    assert_includes response.body, '<feed'
+    assert_includes response.body, @advisory.uuid
+  end
+
   test "should handle valid sort parameters" do
     get advisories_url, params: { sort: "epss_percentage", order: "desc" }
     assert_response :success

--- a/test/controllers/ecosystems_controller_test.rb
+++ b/test/controllers/ecosystems_controller_test.rb
@@ -19,6 +19,30 @@ class EcosystemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "max-age=3600, public, stale-while-revalidate=3600", response.headers["Cache-Control"]
   end
 
+
+  test "ecosystem show provides RSS and Atom auto discovery links" do
+    get ecosystem_url("pypi")
+    assert_response :success
+    assert_select 'link[rel="alternate"][type="application/rss+xml"]'
+    assert_select 'link[rel="alternate"][type="application/atom+xml"]'
+  end
+
+  test "ecosystem show renders RSS feed" do
+    get ecosystem_url("pypi", format: :rss)
+    assert_response :success
+    assert_equal 'application/rss+xml', response.media_type
+    assert_includes response.body, '<rss'
+    assert_includes response.body, @advisory.uuid
+  end
+
+  test "package advisories renders Atom feed" do
+    get ecosystem_package_url("pypi", "tensorflow", format: :atom)
+    assert_response :success
+    assert_equal 'application/atom+xml', response.media_type
+    assert_includes response.body, '<feed'
+    assert_includes response.body, @advisory.uuid
+  end
+
   test "should get ecosystem show page" do
     get ecosystem_url("pypi")
     assert_response :success


### PR DESCRIPTION
Refs #80

## Summary
- adds RSS and Atom feed responses for the main advisories list
- adds RSS and Atom feed responses for ecosystem advisory lists
- adds RSS and Atom feed responses for package advisory lists
- adds feed auto-discovery links in the HTML head for each list page
- adds controller coverage for discovery links and feed responses

## Validation
- `ruby -c app/controllers/advisories_controller.rb`
- `ruby -c app/controllers/ecosystems_controller.rb`
- all RSS/Atom builder syntax checks passed
- `ruby -c test/controllers/advisories_controller_test.rb`
- `ruby -c test/controllers/ecosystems_controller_test.rb`
- `git diff --check`

Full controller test execution is locally blocked because the lockfile requires Bundler 4.0.10 and this system Ruby cannot activate it.