### PR TITLE
Fix grammar in getAdvisory summary

### DIFF
--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -158,7 +158,7 @@ paths:
                     example: "purl or repository_url parameter is required"
   /advisories/{advisoryUUID}:
     get:
-      summary: get a advisories by uuid
+      summary: get an advisory by uuid
       operationId: getAdvisory
       tags:
         - advisories


### PR DESCRIPTION
Corrects `get a advisories by uuid` to `get an advisory by uuid` on the `/advisories/{advisoryUUID}` endpoint.