### PR TITLE
Disable sessions and cookies so CDN can cache HTML

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  skip_forgery_protection
+  before_action { request.session_options[:skip] = true }
   include Pagy::Backend
 
   def default_url_options(options = {})

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
       <%= meta_title %>
     </title>
     <meta name="description" content="<%= meta_description %>">
-    <%= csrf_meta_tags %>
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,10 @@ module Advisories
     config.load_defaults 7.0
     config.exceptions_app = routes
 
+    config.session_store :disabled
+    config.middleware.delete ActionDispatch::Session::CookieStore
+    config.middleware.delete ActionDispatch::Cookies
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ require 'sidekiq/web'
 require 'sidekiq_unique_jobs/web'
 
 Sidekiq::Web.use ActionDispatch::Cookies
-Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_advisories_sidekiq_session', path: '/sidekiq'
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_advisories_sidekiq_session', path: '/sidekiq', secure: Rails.env.production?
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
   ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 require 'sidekiq/web'
 require 'sidekiq_unique_jobs/web'
 
+Sidekiq::Web.use ActionDispatch::Cookies
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_advisories_sidekiq_session', path: '/sidekiq'
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
   ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))

--- a/test/controllers/cache_headers_test.rb
+++ b/test/controllers/cache_headers_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class CacheHeadersTest < ActionDispatch::IntegrationTest
+  test 'html pages do not set cookies' do
+    get '/'
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  test 'advisory show does not set cookies' do
+    advisory = create(:advisory)
+    get advisory_path(advisory)
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  test 'api endpoints do not set cookies' do
+    get api_v1_advisories_path(format: :json)
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+end


### PR DESCRIPTION
`csrf_meta_tags` in the layout writes `_csrf_token` to the session on every render, which forces a `Set-Cookie: _advisories_session=...` header on every response. Cloudflare (with origin cache control) returns `cf-cache-status: BYPASS` for responses carrying `Set-Cookie`, and APISIX `proxy-cache` never stores them, so the existing per-action `expires_in` headers are ignored and every request reaches puma:

```
$ curl -sI https://advisories.ecosyste.ms/
set-cookie: _advisories_session=...
apisix-cache-status: EXPIRED
cf-cache-status: BYPASS
```

There's no login on this app, so:

- `config.session_store :disabled` and remove `ActionDispatch::Cookies` / `Session::CookieStore` from the middleware stack
- drop `csrf_meta_tags` from the layout
- `skip_forgery_protection` + `request.session_options[:skip] = true` in `ApplicationController` (`Osv::ApplicationController` already had `skip_forgery_protection`, which is now redundant but harmless)
- give `Sidekiq::Web` its own session middleware scoped to `/sidekiq` so retry/delete buttons keep working behind basic auth
- tests asserting no `Set-Cookie` on `/`, `/advisories/:id`, and API responses

Same change as ecosyste-ms/awesome#793, which took `cf-cache-status: BYPASS` to `HIT` at both APISIX and Cloudflare.